### PR TITLE
Attempt to fix the alignment of the responsive table layout

### DIFF
--- a/_sass/responsive-table.scss
+++ b/_sass/responsive-table.scss
@@ -16,6 +16,10 @@
 
 .responsive-table {
   text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: space-between;
+  justify-content: space-between;
 
   .item {
     display: inline-block;


### PR DESCRIPTION
Not a complete fix but improves the spacing between cells. A full fix would likely require a responsive grid or a table element

| Before | After |
|--------|------|
|<img width="223" alt="image" src="https://user-images.githubusercontent.com/1331209/80743873-fd931580-8ada-11ea-8af0-4ed6cccfec0d.png"> | <img width="266" alt="image" src="https://user-images.githubusercontent.com/1331209/80743916-126fa900-8adb-11ea-80a5-a3dd8fd29e85.png"> |