### PR TITLE
Add premium call out and inline premium callout

### DIFF
--- a/_sass/website-docs.scss
+++ b/_sass/website-docs.scss
@@ -260,6 +260,10 @@ section.docs {
         color: lighten($documentation-since-color, 7%);
       }
 
+      &.fa-radiation-alt {
+        color: $orange-medium
+      }
+
       /* Replicate a FusionAuth admin UI button Style */
       &.ui-button {
         border-radius: 3px;
@@ -325,18 +329,27 @@ section.docs {
         }
       }
 
-       > span.field {
-         background: darken($gray-1, 5%);
-         border-bottom: 1px solid $orange-medium;
-         font-size: 0.8rem;
-         padding: 1px 3px 0 3px;
-       }
+      > span.field {
+        background: darken($gray-1, 5%);
+        border-bottom: 1px solid $orange-medium;
+        font-size: 0.8rem;
+        padding: 1px 3px 0 3px;
+      }
 
       > span.note {
         color: $blue-dark;
         font-size: 12px;
         font-weight: 500;
         margin-top: 20px;
+        text-transform: uppercase;
+      }
+
+      > span.paid {
+        border-top: solid 1px;
+        border-bottom: solid 1px;
+        color: $gray-5;
+        font-size: 10px;
+        font-weight: 500;
         text-transform: uppercase;
       }
     }
@@ -443,10 +456,29 @@ section.docs {
           font-family: 'Font Awesome 5 Pro';
           font-weight: 300;
         }
+
+        &.paid::before {
+          color: $orange-medium;
+          content: '\f7ba';
+          font-family: 'Font Awesome 5 Pro';
+          font-weight: 300;
+        }
+
       }
 
       &.note {
         border-left: 4px solid $blue-medium;
+
+        &.paid {
+          border-left: 4px solid $orange-medium;
+
+          .icon.note::before {
+            color: $orange-medium;
+            content: '\f7ba';
+            font-family: 'Font Awesome 5 Pro';
+            font-weight: 300;
+          }
+        }
 
         &.since {
           border-left: 4px solid $documentation-since-color;

--- a/website/docs/example.html
+++ b/website/docs/example.html
@@ -309,6 +309,8 @@ show-alerts: true
               <p class="api-authentication">
                 <a href="authentication#api-key-authentication"><i class="fa-lock far"></i></a> Create a User with a randomly generated Id
               </p>
+
+              <i class="icon note"></i>
               <div class="openblock endpoint">
                 <div class="title">URI</div>
                 <div class="content">
@@ -380,6 +382,16 @@ show-alerts: true
                     </div>
                   </div>
 
+                  <div class="admonitionblock note paid">
+                    <i class="icon paid"></i>
+                    <div class="body">
+                      <p>
+                        This is a paid edition feature and is unavailable in the community edition. <br>
+                        Please visit <a href="/website/pricing/">our pricing page</a>to learn more about paid editions.
+                      </p>
+                    </div>
+                  </div>
+
                   <div class="admonitionblock warning database-migration">
                     <i class="icon warning"></i>
                     <div class="body">
@@ -419,6 +431,7 @@ show-alerts: true
                   <p>
                     Indicates to FusionAuth that it should skip email verification even if it is enabled. This is useful for creating admin or internal User accounts.
                   </p>
+                  <p><span class="paid"><i class="orange-text fal fa-radiation-alt"></i> A PAID EDITION OF FUSIONAUTH IS REQUIRED TO UTILIZTE {premium feature}.<i class="orange-text fal fa-radiation-alt"></i> </span></p>
                 </dd>
                 <dt>
                   <p>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -14,7 +14,7 @@ show-alerts: true
         <p>
           FusionAuth gives devs complete flexibility with minimal implementation effort. Dive right into our full documentation, including the APIs, or get started with the links below.
         </p>
-        <a href="#" class="purple brochure button">FULL DOCUMENTATION</a>
+        <a href="/website/docs/example/" class="purple brochure button">FULL DOCUMENTATION</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Summary
 - Add Primary Callout for Premium Features
 - Add Inline callout for API doc for Premium
 - Add a link to documentation example, to direct you to API full docs

# Related PR / Linked PR
- https://github.com/FusionAuth/fusionauth-site/pull/722/files

# Blockers

## 🅰️ I think this looks better

- With everything including the icons in the span
- (from example.html)
![image](https://user-images.githubusercontent.com/16090626/121095304-57214580-c7ad-11eb-939f-57209e93545f.png)


## 🅱️ But had to resort to this

- (as written currently)
![image](https://user-images.githubusercontent.com/16090626/121095373-79b35e80-c7ad-11eb-9e26-66a1fd2c138c.png)

```
icon:radiation-alt[type=fal] [paid]#A paid edition of FusionAuth is required to utilize {premium_feature}.# icon:radiation-alt[type=fal]
```
from `site/docs/v1/tech/shared/_premium-edition-blurb-api.adoc`

## SVN release 

- I don't have SVN right on the style repo
- Just fine, but someone else will have to merge this on my behalf if this PR is approved

# More Screenshots
On example.html
![image](https://user-images.githubusercontent.com/16090626/121095597-d6167e00-c7ad-11eb-8cac-b1d487e5ab6f.png)




