### PR TITLE
Fix for blocked anchors on `/license-faq/`

### DIFF
--- a/_sass/website-helpers.scss
+++ b/_sass/website-helpers.scss
@@ -48,6 +48,10 @@ ul.inline li {
   margin-right: 10px;
 }
 
+.license-faq-answers a {
+  position: relative;
+}
+
 
 /* Width and height
 –––––––––––––––––––––––––––––––––––––––––––––––––– */

--- a/build.savant
+++ b/build.savant
@@ -16,7 +16,7 @@
 savantVersion = "1.0.0"
 primejsVersion = "1.5.0"
 
-project(group: "io.fusionauth", name: "fusionauth-style", version: "0.3.33", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-style", version: "0.3.34", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }


### PR DESCRIPTION
Very simple fix to add `position: relative;` to all the `<a>` anchors on the page.  This unblocks them from the `<h3>`s that are sitting on top of them currently.

See also the related PR [#816](https://github.com/FusionAuth/fusionauth-site/pull/816)