### PR TITLE
Add orange button color

### DIFF
--- a/_sass/website-colors.scss
+++ b/_sass/website-colors.scss
@@ -29,6 +29,7 @@ $orange-light: #FDBA74;
 $orange-medium: #F58320;
 $orange-dark: #C2410C;
 $orange-section-gradient: linear-gradient($orange-light, $orange-dark);
+$orange-ui-button-bg: #FF9C3D;
 
 $red-light: #FDA4AF;
 $red-medium: #F43F5E;

--- a/_sass/website-docs.scss
+++ b/_sass/website-docs.scss
@@ -296,6 +296,11 @@ section.docs {
           background-color: $red-ui-button-bg !important;
         }
 
+        &.orange {
+          color: #fff;
+          background-color: $orange-ui-button-bg !important;
+        }
+
         &.gray {
           padding: 6px;
           color: $gray-ui-button-fg;


### PR DESCRIPTION
When selecting users in the user list, the "Remove from Group" is orange.

<img width="789" alt="CleanShot 2023-08-07 at 16 29 27@2x" src="https://github.com/FusionAuth/fusionauth-style/assets/5517677/9949bb44-8b6e-4f09-8836-906ae027cb14">