### PR TITLE
adds input[type=datetime-local] to the standard forms styles

### DIFF
--- a/_sass/forms.scss
+++ b/_sass/forms.scss
@@ -84,6 +84,7 @@ form {
     input[type="url"],
     input[type="password"],
     input[type="date"],
+    input[type="datetime-local"],
     textarea,
     select {
       width: 100%;
@@ -217,6 +218,7 @@ input[type="tel"],
 input[type="url"],
 input[type="password"],
 input[type="date"],
+input[type="datetime-local"],
 textarea {
   appearance: none;
   background: $input-background-color;
@@ -345,6 +347,7 @@ input[type=range] {
   input[type="url"],
   input[type="password"],
   input[type="date"],
+  input[type="datetime-local"],
   textarea {
     font-size: $input-font-size-desktop;
   }

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 primejsVersion = "1.5.0"
 
-project(group: "io.fusionauth", name: "fusionauth-style", version: "0.3.75", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-style", version: "0.3.76", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()


### PR DESCRIPTION
what it says in the tile. This way the native html datetime picker will look right in FusionAuth